### PR TITLE
Large number of cookies exceeding the defined buffer size can crash the script

### DIFF
--- a/jsh.py
+++ b/jsh.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import socket
 import sys
-from requests import get
 import argparse
+
+from requests import get
 
 
 red = '\033[1;31m'
@@ -36,7 +37,6 @@ parser.add_argument('-t', help='target to be used in payloads, default: [host]:[
 parser.add_argument('-c', help='command to execute after get the shell', dest='command', default=str())
 parser.add_argument('-w', help='timeout for shell connection', dest='secs', type=float, default=0)
 parser.add_argument('-q', help='quiet mode', dest='quiet', action='store_true')
-parser.add_argument('-b', help='buffer size (default:1024)', dest='buffer', default=1024)
 
 args = parser.parse_args()
 
@@ -45,7 +45,6 @@ target = args.target
 gene = args.gene
 cmd = args.command
 secs = args.secs
-buffersize = args.buffer 
     
 try:
     port = int(format(args.port))
@@ -175,7 +174,10 @@ def main():
 
     try:
         c, addr = s.accept()
-        resp = c.recv(int(buffersize)).decode()
+        resp = ""
+        while b:
+            b = c.recv(1024).decode()
+            resp += b
     except KeyboardInterrupt:
         if sys.platform == 'win32':
                 print('\nControl-C')

--- a/jsh.py
+++ b/jsh.py
@@ -36,7 +36,7 @@ parser.add_argument('-t', help='target to be used in payloads, default: [host]:[
 parser.add_argument('-c', help='command to execute after get the shell', dest='command', default=str())
 parser.add_argument('-w', help='timeout for shell connection', dest='secs', type=float, default=0)
 parser.add_argument('-q', help='quiet mode', dest='quiet', action='store_true')
-
+parser.add_argument('-b', help='buffer size (default:1024)', dest='buffer', default=1024)
 
 args = parser.parse_args()
 
@@ -45,6 +45,7 @@ target = args.target
 gene = args.gene
 cmd = args.command
 secs = args.secs
+buffersize = args.buffer 
     
 try:
     port = int(format(args.port))
@@ -174,7 +175,7 @@ def main():
 
     try:
         c, addr = s.accept()
-        resp = c.recv(1024).decode()
+        resp = c.recv(int(buffersize)).decode()
     except KeyboardInterrupt:
         if sys.platform == 'win32':
                 print('\nControl-C')

--- a/jsh.py
+++ b/jsh.py
@@ -175,16 +175,19 @@ def main():
     try:
         c, addr = s.accept()
         resp = ""
-        while b:
+        while True:
             b = c.recv(1024).decode()
+            if not b:
+                break
             resp += b
     except KeyboardInterrupt:
         if sys.platform == 'win32':
                 print('\nControl-C')
         exit()
-    except:
+    except(e):
+        print(e)
         s.close()
-        main()
+        
 
     if 'Accept' in resp and 'HTTP' in resp:
         print('Got JS shell from [%s] port %s to %s %s' % (addr[0], addr[1], socket.gethostname(), port))


### PR DESCRIPTION
I recently discovered that if a target has a large number of cookies the script doesn't handle it well and starts crashing. for instance, if an app has the following cookies set.

![image](https://user-images.githubusercontent.com/18637512/208663597-80ac278f-bb5c-43d6-aece-1351edbda343.png)

and if the client is listening to a connection on JSshell, the moment the target will send a large number of cookies the script will restart, refer to the below screenshot.

![image](https://user-images.githubusercontent.com/18637512/208663977-259111f7-f3af-4141-a4cf-db5a0369f971.png)

The reason why the above behavior is happening is because of the following lines of code.

```python
 try:
        c, addr = s.accept()
        resp = c.recv(1024).decode()
    except KeyboardInterrupt:
        if sys.platform == 'win32':
                print('\nControl-C')
        exit()
    except:
        s.close()
        main()
```

In the above code, the buffer size for `c.recv` is hard coded to the value of `1024` so if a response is received that is greater than the buffer size the application throws an exception and starts the `main()` function again.

To tackle this problem I have introduced `-b` flag using which users can provide a custom buffer size if the target application is storing a large number of cookies.

